### PR TITLE
Added Harrier and Updated requiredAddons

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Additional third party addon support:
 [F-35C] (https://github.com/RealityGaming/OK_F_35C)  
 [Peral A-10C] (http://forums.bistudio.com/showthread.php?172682-A-10C-for-Arma-3)  
 [STI A-10A] (http://forums.bistudio.com/showthread.php?175871-STI-Addons)  
+[AV-8B Harrier II](http://forums.bistudio.com/showthread.php?183415-Arma-2-AV-8B-Harrier-II-Port)
 
 Debugging
 =========

--- a/src/CCIP_B_Heli_Light_01_armed_F/config.cpp
+++ b/src/CCIP_B_Heli_Light_01_armed_F/config.cpp
@@ -4,7 +4,7 @@ class CfgPatches
     {
         units[] = {"B_Heli_Light_01_armed_F"};
         weapons[] = {};
-        requiredAddons[] = {"A3_Air_F_Heli_Light_01"};
+        requiredAddons[] = {"CCIP_Core","A3_Air_F_Heli_Light_01"};
         author[]= {"eRazeri"};
     };
 };

--- a/src/CCIP_B_Plane_CAS_01_F/config.cpp
+++ b/src/CCIP_B_Plane_CAS_01_F/config.cpp
@@ -4,7 +4,7 @@ class CfgPatches
     {
         units[] = {"B_Plane_CAS_01_F"};
         weapons[] = {};
-        requiredAddons[] = {"A3_Air_F_EPC_Plane_CAS_01"};
+        requiredAddons[] = {"CCIP_Core","A3_Air_F_EPC_Plane_CAS_01"};
         author[]= {"eRazeri"};
     };
 };

--- a/src/CCIP_Cha_AV8B/config.cpp
+++ b/src/CCIP_Cha_AV8B/config.cpp
@@ -1,0 +1,28 @@
+class CfgPatches
+{
+    class CCIP_Cha_AV8B
+    {
+        units[] = {"Cha_AV8B","Cha_AV8B2","Cha_AV8B3"};
+        weapons[] = {};
+        requiredAddons[] = {"CCIP_Core","Cha_AV8B"};
+        author[]= {"Jonpas"};
+    };
+};
+class CfgVehicles
+{
+    class Plane;
+    class Cha_AV8B2: Plane
+    {
+        CCIP_Configured = 1;
+        CCIP_Allowed_Weapons[]= {
+            "Cha_gatling_25mm",
+            "Cha_GBU12BombLauncher",
+            "Cha_FFAR_Smallpod"
+        };
+        CCIP_Weapon_Positions[]= {
+            {"Cha_gatling_25mm",{-0.25,14,-1}},
+            {"Cha_GBU12BombLauncher",{0,14,-1}},
+            {"Cha_FFAR_Smallpod",{0,14,-1}}
+        };
+    };
+};

--- a/src/CCIP_I_Plane_Fighter_03_AA_F/config.cpp
+++ b/src/CCIP_I_Plane_Fighter_03_AA_F/config.cpp
@@ -4,7 +4,7 @@ class CfgPatches
     {
         units[] = {"I_Plane_Fighter_03_AA_F"};
         weapons[] = {};
-        requiredAddons[] = {"A3_Air_F_Gamma_Plane_Fighter_03","A3_Air_F_EPC_Plane_Fighter_03"};
+        requiredAddons[] = {"CCIP_Core","A3_Air_F_Gamma_Plane_Fighter_03","A3_Air_F_EPC_Plane_Fighter_03"};
         author[]= {"eRazeri"};
     };
 };

--- a/src/CCIP_I_Plane_Fighter_03_CAS_F/config.cpp
+++ b/src/CCIP_I_Plane_Fighter_03_CAS_F/config.cpp
@@ -4,7 +4,7 @@ class CfgPatches
     {
         units[] = {"I_Plane_Fighter_03_CAS_F"};
         weapons[] = {};
-        requiredAddons[] = {"A3_Air_F_Gamma_Plane_Fighter_03","A3_Air_F_EPC_Plane_Fighter_03"};
+        requiredAddons[] = {"CCIP_Core","A3_Air_F_Gamma_Plane_Fighter_03","A3_Air_F_EPC_Plane_Fighter_03"};
         author[]= {"eRazeri"};
     };
 };

--- a/src/CCIP_JS_JC_FA18/config.cpp
+++ b/src/CCIP_JS_JC_FA18/config.cpp
@@ -4,7 +4,7 @@ class CfgPatches
     {
         units[] = {"JS_JC_FA18E","JS_JC_FA18F"};
         weapons[] = {};
-        requiredAddons[] = {"JS_JC_FA18"};
+        requiredAddons[] = {"CCIP_Core","JS_JC_FA18"};
         author[]= {"eRazeri"};
     };
 };

--- a/src/CCIP_JS_JC_FA18X/config.cpp
+++ b/src/CCIP_JS_JC_FA18X/config.cpp
@@ -4,7 +4,7 @@ class CfgPatches
     {
         units[] = {"JS_S_FA18X"};
         weapons[] = {};
-        requiredAddons[] = {"JS_S_FA18X"};
+        requiredAddons[] = {"CCIP_Core","JS_S_FA18X"};
         author[]= {"eRazeri"};
     };
 };

--- a/src/CCIP_JS_JC_SU35/config.cpp
+++ b/src/CCIP_JS_JC_SU35/config.cpp
@@ -4,7 +4,7 @@ class CfgPatches
     {
         units[] = {"JS_JC_SU35"};
         weapons[] = {};
-        requiredAddons[] = {"JS_JC_SU35"};
+        requiredAddons[] = {"CCIP_Core","JS_JC_SU35"};
         author[]= {"eRazeri"};
     };
 };

--- a/src/CCIP_OK_F_35C/config.cpp
+++ b/src/CCIP_OK_F_35C/config.cpp
@@ -4,7 +4,7 @@ class CfgPatches
     {
         units[] = {"F_35C","F_35C_I"};
         weapons[] = {};
-        requiredAddons[] = {"F_35C"};
+        requiredAddons[] = {"CCIP_Core","F_35C"};
         author[]= {"eRazeri"};
     };
 };

--- a/src/CCIP_O_Plane_CAS_02_F/config.cpp
+++ b/src/CCIP_O_Plane_CAS_02_F/config.cpp
@@ -4,7 +4,7 @@ class CfgPatches
     {
         units[] = {"O_Plane_CAS_02_F"};
         weapons[] = {};
-        requiredAddons[] = {"A3_Air_F_EPC_Plane_CAS_02"};
+        requiredAddons[] = {"CCIP_Core","A3_Air_F_EPC_Plane_CAS_02"};
         author[]= {"eRazeri"};
     };
 };

--- a/src/CCIP_Peral_A10/config.cpp
+++ b/src/CCIP_Peral_A10/config.cpp
@@ -4,7 +4,7 @@ class CfgPatches
     {
         units[] = {"Peral_A10C"};
         weapons[] = {};
-        requiredAddons[] = {"Peral_A10"};
+        requiredAddons[] = {"CCIP_Core","Peral_A10"};
         author[]= {"eRazeri"};
     };
 };

--- a/src/CCIP_STI_A10/config.cpp
+++ b/src/CCIP_STI_A10/config.cpp
@@ -4,7 +4,7 @@ class CfgPatches
     {
         units[] = {"STI_A10A"};
         weapons[] = {};
-        requiredAddons[] = {"sti_A10"};
+        requiredAddons[] = {"CCIP_Core","sti_A10"};
         author[]= {"eRazeri"};
     };
 };


### PR DESCRIPTION
Added support for [AV-8B Harrier II from Chairborne](http://forums.bistudio.com/showthread.php?183415-Arma-2-AV-8B-Harrier-II-Port), used center for bombs and rockets, because it isn't separated into 2 weapons as in eg. vanilla aircraft.

Updated requiredAddons with CCIP_Core, as no optional PBO should be loaded alone anyways.
